### PR TITLE
makeqctoolsreport - fix transcode function and add shebang

### DIFF
--- a/makeqctoolsreport.py
+++ b/makeqctoolsreport.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #makeqctoolsreport.py v 0.2.0
 
 import os
@@ -56,9 +57,16 @@ def parseInput():
 
 def transcode():
 	#transcode to .nut	
-	ffmpegstring = 'ffmpeg' + inputCodec + '-vsync 0 -i ' + startObj + ' -vcodec rawvideo -acodec pcm_s24le' + filterstring + '-f nut -y ' + startObj + '.temp1.nut'
+  
+	ffmpegstring = ['ffmpeg'] 
+	if not inputCodec == ' ':
+		ffmpegstring.append(inputCodec)
+	ffmpegstring.extend(['-vsync','0','-i',startObj,'-vcodec','rawvideo','-acodec','pcm_s24le'])
+	if not filterstring== ' ':
+		ffmpegstring.append(inputCodec)
+	ffmpegstring.extend(['-f','nut','-y',startObj + '%s' % '.temp1.nut'])
 	subprocess.call(ffmpegstring)
-	return
+	
 
 def makeReport():
 	#here's where we use ffprobe to make the qctools report in regular xml


### PR DESCRIPTION
Initially ffmpegstring was a string, but subprocess.call requires a list of arguments. Here was the error that I kept getting:

```
Traceback (most recent call last):
  File "makeqctoolsreport.py", line 81, in <module>
    transcode()
  File "makeqctoolsreport.py", line 60, in transcode
    subprocess.call(ffmpegstring)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

This pull request turns the command into a list. Because `inputCodec` and `filterString` can be empty, it causes the ffmpeg command to fail, which is why the `if` statement is there.

Why is the transcode necessary at all? Can't you just run ffprobe on the source file directly?

Also I added a shebang for good measure.

