### PR TITLE
makeqctoolsreport - add audio stream count - fixes #4

### DIFF
--- a/makeqctoolsreport.py
+++ b/makeqctoolsreport.py
@@ -66,13 +66,24 @@ def transcode():
 		ffmpegstring.append(inputCodec)
 	ffmpegstring.extend(['-f','nut','-y',startObj + '%s' % '.temp1.nut'])
 	subprocess.call(ffmpegstring)
-	
 
+	
+def get_audio_stream_count():
+	audio_stream_count = subprocess.check_output(['ffprobe', '-v', 'error', '-select_streams', 'a', '-show_entries', 'stream=index','-of', 'flat', sys.argv[1]]).splitlines()
+	return len(audio_stream_count)
+	
+	
 def makeReport():
 	#here's where we use ffprobe to make the qctools report in regular xml
 	print "writing ffprobe output to xml"
+	audio_tracks = get_audio_stream_count()
+	if audio_tracks > 0:
+		ffprobe_command = ['ffprobe','-loglevel','error','-f','lavfi','-i','movie=' + startObj + ':s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng,cropdetect=reset=1,split[a][b];[a]field=top[a1];[b]field=bottom[b1],[a1][b1]psnr[out0];[in1]ebur128=metadata=1[out1]','-show_frames','-show_versions','-of','xml=x=1:q=1','-noprivate']
+	elif audio_tracks == 0:
+		ffprobe_command = ['ffprobe','-loglevel','error','-f','lavfi','-i','movie=' + startObj + ',signalstats=stat=tout+vrep+brng,cropdetect=reset=1,split[a][b];[a]field=top[a1];[b]field=bottom[b1],[a1][b1]psnr','-show_frames','-show_versions','-of','xml=x=1:q=1','-noprivate']
+	
 	tmpxml = open(startObj + '.qctools.xml','w')
-	subprocess.call(['ffprobe','-loglevel','error','-f','lavfi','-i','movie=' + startObj + ':s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng,cropdetect=reset=1,split[a][b];[a]field=top[a1];[b]field=bottom[b1],[a1][b1]psnr[out0];[in1]ebur128=metadata=1[out1]','-show_frames','-show_versions','-of','xml=x=1:q=1','-noprivate'], stdout=tmpxml)
+	subprocess.call(ffprobe_command, stdout=tmpxml)
 	tmpxml.close()
 
 	#gzip that tmpxml file then delete the regular xml file cause we dont need it anymore


### PR DESCRIPTION
This probably could have gone into the `parseInput` function but as that was using a regex to parse the log file, I thought that this could exist as a standalone function. Also there might be better ways to get the stream count than this but i think it works OK. The very latest version of mediainfo now has a stream counter but it is so new that it would require that everyone has the very latest version.